### PR TITLE
Updated to support Arris SB6183 and refactored code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-CMD [ "python", "scrape.py" ]
+CMD [ "python3", "scrape.py" ]

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A preset Grafana dashboard is included with this project with some alerts that m
 
 #### First
 
-Copy `config_sample.py` to `config.py` and fill in your modem's URL as well as your InfluxDB hostname. Depending on your InfluxDB configuration, you may need to add more options (e.g. authentication). See the `influxdb.InfluxDBClient` Python module for all possibilities.
+Copy `config_sample.py` to `config.py` and fill in your modem's URL and model as well as your InfluxDB hostname. Depending on your InfluxDB configuration, you may need to add more options (e.g. authentication). See the `influxdb.InfluxDBClient` Python module for all possibilities.
 
 #### Python only
 
@@ -69,6 +69,6 @@ Import the included [Grafana JSON](full-service/grafana_dashboards) and tweak ap
 
 ## Extending
 
-There's a good chance your modem status page doesn't match this one, but you want to accomplish the same task. If your modem allows you to see a status page without any authentication but it just has a different layout, then adapting is straightforward. Just clone the `arris_modem.py` target and change the fields and xpath queries as needed. Use the `PrinterOutputter` to see what data points would be uploaded to InfluxDB before doing any real uploading.
+There's a good chance your modem status page doesn't match this one, but you want to accomplish the same task. If your modem allows you to see a status page without any authentication but it just has a different layout, then adapting is straightforward. Just create a new subclass of `arris_modem.py` target and change the fields and xpath queries as needed. Use the `PrinterOutputter` to see what data points would be uploaded to InfluxDB before doing any real uploading.
 
 If your modem requires some form of authentication, you'll need to implement that part. It may be as simple as snooping on HTTP headers using your browser to see what the script needs to send.

--- a/config_sample.py
+++ b/config_sample.py
@@ -2,9 +2,11 @@
 Parameters for the modem scraper.
 """
 scraper_config = {
+    'modem_model' '', #POPULATE MODEM MODEL HERE
     'modem_url': '', # POPULATE MODEM URL HERE
     'max_retries': 5,
     'poll_interval_seconds': 30
+    'outputter' : 'influxdb' # Output to influxdb or print
 }
 
 """

--- a/config_sample.py
+++ b/config_sample.py
@@ -2,7 +2,7 @@
 Parameters for the modem scraper.
 """
 scraper_config = {
-    'modem_model' '', #POPULATE MODEM MODEL HERE
+    'modem_model' '', # POPULATE MODEM MODEL HERE
     'modem_url': '', # POPULATE MODEM URL HERE
     'max_retries': 5,
     'poll_interval_seconds': 30

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 influxdb
 lxml
 requests
+bs4
+html5lib

--- a/scrape.py
+++ b/scrape.py
@@ -2,12 +2,14 @@ import sys
 import time
 
 from config import scraper_config, influx_config
-from scraper.targets.arris_modem import ArrisModem
 from scraper.outputters import InfluxDBOutputter
+from scraper.outputters import PrinterOutputter
 from scraper.downloaders import RequestsDownloader
 
 MAX_RETRIES = scraper_config['max_retries']
 MODEM_URL = scraper_config['modem_url']
+MODEM_MODEL = scraper_config['modem_model']
+OUTPUTTER = scraper_config['outputter']
 
 def run_scraper():
     """
@@ -15,8 +17,8 @@ def run_scraper():
     """
     print("Modem scraper running.")
 
-    target = ArrisModem()
-    outputter = InfluxDBOutputter(influx_config)
+    target = get_target(MODEM_MODEL)
+    outputter = get_outputter(OUTPUTTER)
     downloader = RequestsDownloader()
 
     retries = 0
@@ -39,6 +41,22 @@ def run_scraper():
     print("Abort! Max retries reached:", MAX_RETRIES)
     sys.exit(1)
 
+def get_target(model):
+    if model == "SB6183":
+        from scraper.targets.arris_modem_SB6183 import ArrisModemSB6183
+        return ArrisModemSB6183()
+    if model == "TM1602AP2":
+        from scraper.targets.arris_modem_TM1602AP2 import ArrisModemTM1602AP2
+        return ArrisModemTM1602AP2()
+    if model == "CM802A":
+        from scraper.targets.arris_modem_CM802A import ArrisModemCM802A
+        return ArrisModemCM802A()
+
+def get_outputter(output):
+    if output == 'influxdb':
+        return InfluxDBOutputter(influx_config)
+    else:
+        return PrinterOutputter()
 
 if __name__ == "__main__":
     run_scraper()

--- a/scraper/targets/arris_modem.py
+++ b/scraper/targets/arris_modem.py
@@ -6,21 +6,49 @@ from lxml import html
 from ..target import Target
 from ..items import InfluxableItem
 
+
 class ArrisModem(Target):
     """
-    Target subclass that represents an Arris modem model TM1602AP2
-    running software 9.1.103J6J.
+    Target subclass that represents an Arris modem model
 
     Args:
         Target (string): [HTML]
     """
+    
     def extract_items_from_html(self, html_string):
         # get items from the downstream table
-        downstream_items = get_downstream_items(html_string)
+        downstream_items = self.get_downstream_items(html_string)
         # get items from the upstream table
-        upstream_items = get_upstream_items(html_string)
+        upstream_items = self.get_upstream_items(html_string)
 
         return downstream_items + upstream_items
+
+    def get_downstream_items(self,html_string):
+        """
+        Function to convert an HTML string to a list of DownstreamItems.
+
+        Args:
+            html_string (string): HTML
+
+        Returns:
+            [DownstreamItem]: List of DownstreamItems
+        """
+        # Override in subclass for individual modem model
+        pass
+
+
+    def get_upstream_items(self,html_string):
+        """
+        Function to convert an HTML string to a list of UpstreamItems.
+
+        Args:
+            html_string (string): HTML
+
+        Returns:
+            [UpstreamItem]: List of UpstreamItems
+        """
+        # Override in subclass for individual modem model
+        pass
 
 class DownstreamItem(InfluxableItem):
     """
@@ -83,72 +111,4 @@ class UpstreamItem(InfluxableItem):
         }
 
 
-def get_downstream_items(html_string):
-    """
-    Function to convert an HTML string to a list of DownstreamItems.
 
-    Args:
-        html_string (string): HTML
-
-    Returns:
-        [DownstreamItem]: List of DownstreamItems
-    """
-    tree = html.fromstring(html_string)
-    # grab the downstream table and skip the first row
-    rows = tree.xpath('/html/body/div[1]/div[3]/table[2]/tbody//tr[position()>1]')
-
-    # key order must match the table column layout
-    keys = [
-        'downstream_id',
-        'dcid',
-        'freq',
-        'power',
-        'snr',
-        'modulation',
-        'octets',
-        'correcteds',
-        'uncorrectables'
-    ]
-
-    items = []
-
-    for row in rows:
-        values = row.xpath('td/text()')
-        zipped = dict(zip(keys, values))
-        items.append(DownstreamItem(zipped.items()))
-
-    return items
-
-def get_upstream_items(html_string):
-    """
-    Function to convert an HTML string to a list of UpstreamItems.
-
-    Args:
-        html_string (string): HTML
-
-    Returns:
-        [UpstreamItem]: List of UpstreamItems
-    """
-    tree = html.fromstring(html_string)
-    # grab the upstream table and skip the first row
-    rows = tree.xpath('/html/body/div[1]/div[3]/table[4]/tbody//tr[position()>1]')
-
-    # key order must match the table column layout
-    keys = [
-        'upstream_id',
-        'ucid',
-        'freq',
-        'power',
-        'channel_type',
-        'symbol_rate',
-        'modulation'
-    ]
-
-    items = []
-
-    for row in rows:
-        values = row.xpath('td/text()')
-        zipped = dict(zip(keys, values))
-        items.append(UpstreamItem(zipped.items()))
-
-    return items

--- a/scraper/targets/arris_modem_CM820A.py
+++ b/scraper/targets/arris_modem_CM820A.py
@@ -9,11 +9,8 @@ from .arris_modem import ArrisModem, UpstreamItem, DownstreamItem
 
 class ArrisModemCM820A(ArrisModem):
     """
-    Target subclass that represents an Arris modem model CM820A
+    ArrisModem subclass that represents an Arris modem model CM820A
     running software 9.1.103S.
-
-    Args:
-        Target (string): [HTML]
     """
 
     def get_downstream_items(self,html_string):

--- a/scraper/targets/arris_modem_CM820A.py
+++ b/scraper/targets/arris_modem_CM820A.py
@@ -15,13 +15,6 @@ class ArrisModemCM820A(ArrisModem):
     Args:
         Target (string): [HTML]
     """
-    #def extract_items_from_html(self, html_string):
-        #get items from the downstream table
-        #downstream_items = get_downstream_items(html_string)
-        #get items from the upstream table
-        #upstream_items = get_upstream_items(html_string)
-
-        #return downstream_items + upstream_items
 
     def get_downstream_items(self,html_string):
         """

--- a/scraper/targets/arris_modem_SB6183.py
+++ b/scraper/targets/arris_modem_SB6183.py
@@ -10,19 +10,9 @@ from .arris_modem import ArrisModem, UpstreamItem, DownstreamItem
 
 class ArrisModemSB6183(ArrisModem):
     """
-    Target subclass that represents an Arris modem model SB6183
+    ArrisModem subclass that represents an Arris modem model SB6183
     running software 
-
-    Args:
-        Target (string): [HTML]
     """
-    #def extract_items_from_html(self, html_string):
-        #get items from the downstream table
-        #downstream_items = get_downstream_items(html_string)
-        #get items from the upstream table
-        #upstream_items = get_upstream_items(html_string)
-
-        #return downstream_items + upstream_items
 
     def get_downstream_items(self,html_string):
         """

--- a/scraper/targets/arris_modem_SB6183.py
+++ b/scraper/targets/arris_modem_SB6183.py
@@ -1,0 +1,120 @@
+"""
+Arris modem module.
+"""
+from lxml import html
+
+from ..target import Target
+from ..items import InfluxableItem
+from bs4 import BeautifulSoup
+from .arris_modem import ArrisModem, UpstreamItem, DownstreamItem
+
+class ArrisModemSB6183(ArrisModem):
+    """
+    Target subclass that represents an Arris modem model SB6183
+    running software 
+
+    Args:
+        Target (string): [HTML]
+    """
+    #def extract_items_from_html(self, html_string):
+        #get items from the downstream table
+        #downstream_items = get_downstream_items(html_string)
+        #get items from the upstream table
+        #upstream_items = get_upstream_items(html_string)
+
+        #return downstream_items + upstream_items
+
+    def get_downstream_items(self,html_string):
+        """
+        Function to convert an HTML string to a list of DownstreamItems.
+
+        Args:
+            html_string (string): HTML
+
+        Returns:
+            [DownstreamItem]: List of DownstreamItems
+        """
+
+        # Use BeautifulSoup with html5lib. lxml doesn't play well with the SB6183.
+        soup = BeautifulSoup(html_string, 'html5lib')
+        
+        # key order must match the table column layout
+        keys = [
+            'downstream_id',
+            'lock_status',
+            'modulation',
+            'dcid',
+            'freq',
+            'power',
+            'snr',
+            'correcteds',
+            'uncorrectables',
+            'octets',
+        ]
+        items = []
+        
+        for table_row in soup.find_all("table")[2].find_all("tr")[2:]:
+    #       print(table_row.find_all('td'))
+            if table_row.th:
+                continue
+            channel = table_row.find_all('td')[0].text.strip()
+            lock_status = table_row.find_all('td')[1].text.strip()
+            modulation = table_row.find_all('td')[2].text.strip()
+            channel_id = table_row.find_all('td')[3].text.strip()
+            frequency = table_row.find_all('td')[4].text.replace(" Hz", "").strip()
+            power = table_row.find_all('td')[5].text.replace(" dBmV", "").strip()
+            snr = table_row.find_all('td')[6].text.replace(" dB", "").strip()
+            corrected = table_row.find_all('td')[7].text.strip()
+            uncorrectables = table_row.find_all('td')[8].text.strip()
+            octets = "0"
+
+    #        print("Channel = %s, Channel ID = %s, Frequency = %s, Power = %s, SNR = %s, corrected = %s, uncorrectables = %s" % (channel, channel_id, frequency, power, snr, corrected, uncorrectables))
+            values = ( channel, lock_status, modulation, channel_id, frequency, power, snr, corrected, uncorrectables, octets )
+            zipped = dict(zip(keys, values))
+            items.append(DownstreamItem(zipped.items()))
+        
+        return items
+
+    def get_upstream_items(self,html_string):
+        """
+        Function to convert an HTML string to a list of UpstreamItems.
+
+        Args:
+            html_string (string): HTML
+
+        Returns:
+            [UpstreamItem]: List of UpstreamItems
+        """
+        # Use BeautifulSoup with html5lib. lxml doesn't play well with the SB6183.
+        soup = BeautifulSoup(html_string, 'html5lib')
+
+        # key order must match the table column layout
+        keys = [
+            'upstream_id',
+            'lock_status',
+            'channel_type',
+            'ucid',
+            'symbol_rate',
+            'freq',
+            'power',
+        ]
+
+        items = []
+
+        # upstream table
+        for table_row in soup.find_all("table")[3].find_all("tr")[2:]:
+            if table_row.th:
+                continue
+            upstream_id = table_row.find_all('td')[0].text.strip()
+            lock_status = table_row.find_all('td')[1].text.strip()
+            channel_type = table_row.find_all('td')[2].text.strip()
+            ucid = table_row.find_all('td')[3].text.strip()
+            symbol_rate = table_row.find_all('td')[4].text.replace(" Ksym/sec", "").strip()
+            freq = table_row.find_all('td')[5].text.replace(" Hz", "").strip()
+            power = table_row.find_all('td')[6].text.replace(" dBmV", "").strip()
+
+            values = (upstream_id, lock_status, channel_type, ucid, symbol_rate, freq, power )
+            zipped = dict(zip(keys, values))
+            items.append(UpstreamItem(zipped.items()))
+
+        return items

--- a/scraper/targets/arris_modem_SB6183.py
+++ b/scraper/targets/arris_modem_SB6183.py
@@ -54,7 +54,6 @@ class ArrisModemSB6183(ArrisModem):
         items = []
         
         for table_row in soup.find_all("table")[2].find_all("tr")[2:]:
-    #       print(table_row.find_all('td'))
             if table_row.th:
                 continue
             channel = table_row.find_all('td')[0].text.strip()

--- a/scraper/targets/arris_modem_SB6183.py
+++ b/scraper/targets/arris_modem_SB6183.py
@@ -68,7 +68,6 @@ class ArrisModemSB6183(ArrisModem):
             uncorrectables = table_row.find_all('td')[8].text.strip()
             octets = "0"
 
-    #        print("Channel = %s, Channel ID = %s, Frequency = %s, Power = %s, SNR = %s, corrected = %s, uncorrectables = %s" % (channel, channel_id, frequency, power, snr, corrected, uncorrectables))
             values = ( channel, lock_status, modulation, channel_id, frequency, power, snr, corrected, uncorrectables, octets )
             zipped = dict(zip(keys, values))
             items.append(DownstreamItem(zipped.items()))

--- a/scraper/targets/arris_modem_TM1602AP2.py
+++ b/scraper/targets/arris_modem_TM1602AP2.py
@@ -7,14 +7,15 @@ from ..target import Target
 from ..items import InfluxableItem
 from .arris_modem import ArrisModem, UpstreamItem, DownstreamItem
 
-class ArrisModemCM820A(ArrisModem):
+class ArrisModemTM1602AP2(ArrisModem):
     """
-    Target subclass that represents an Arris modem model CM820A
-    running software 9.1.103S.
+    Target subclass that represents an Arris modem model TM1602AP2
+    running software 9.1.103J6J.
 
     Args:
         Target (string): [HTML]
     """
+
     #def extract_items_from_html(self, html_string):
         #get items from the downstream table
         #downstream_items = get_downstream_items(html_string)
@@ -22,6 +23,7 @@ class ArrisModemCM820A(ArrisModem):
         #upstream_items = get_upstream_items(html_string)
 
         #return downstream_items + upstream_items
+
 
     def get_downstream_items(self,html_string):
         """
@@ -71,8 +73,7 @@ class ArrisModemCM820A(ArrisModem):
         """
         tree = html.fromstring(html_string)
         # grab the upstream table and skip the first row
-        # CM820A upstream tables have a blank record so set start record to 2 or higher
-        rows = tree.xpath('/html/body/div[1]/div[3]/table[4]/tbody//tr[position()>2]')
+        rows = tree.xpath('/html/body/div[1]/div[3]/table[4]/tbody//tr[position()>1]')
 
         # key order must match the table column layout
         keys = [


### PR DESCRIPTION
This pull request includes the following changes:

- Added support for the Arris SB6183 
(Derived from https://github.com/billimek/SB6183-stats-for-influxdb/blob/master/SB6183.py) 

- Added support for modem model in config.py

- Added support for the Printer outputter as a config.py option

- Refactored code so that all modem models are subclasses of ArrisModem
